### PR TITLE
Move Windows AppVeyor build from Shapely to here

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 Changes
 =======
+## 2020-00-00
+
+* Move Windows AppVeyor build from Shapely to here.
 
 ## 2020-02-29
 

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ shapely-wheels
 This projects uses https://github.com/matthew-brett/multibuild to build wheels
 for the [Shapely](https://github.com/Toblerity/Shapely) package.
 
-[![Build Status](https://travis-ci.com/shapely/shapely-wheels.svg?branch=master)](https://travis-ci.com/shapely/shapely-wheels)
+[![Travis CI](https://travis-ci.com/shapely/shapely-wheels.svg?branch=master)](https://travis-ci.com/shapely/shapely-wheels)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/shapely/shapely-wheels?branch=master&svg=true)](https://ci.appveyor.com/project/frsci/shapely-wheels?branch=master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,106 @@
+---
+image: Visual Studio 2017
+platform: x64
+
+environment:
+  global:
+    GEOS_VERSION: "3.8.1"
+
+  matrix:
+    - PYTHON: "C:\\Python35"
+      ARCH: x86
+      COMPILER: msvc2017
+    - PYTHON: "C:\\Python35-x64"
+      ARCH: x64
+      COMPILER: msvc2017
+    - PYTHON: "C:\\Python36"
+      ARCH: x86
+      COMPILER: msvc2017
+    - PYTHON: "C:\\Python36-x64"
+      ARCH: x64
+      COMPILER: msvc2017
+    - PYTHON: "C:\\Python37"
+      ARCH: x86
+      COMPILER: msvc2017
+    - PYTHON: "C:\\Python37-x64"
+      ARCH: x64
+      COMPILER: msvc2017
+    - PYTHON: "C:\\Python38"
+      ARCH: x86
+      COMPILER: msvc2017
+    - PYTHON: "C:\\Python38-x64"
+      ARCH: x64
+      COMPILER: msvc2017
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+
+build_script:
+  - set _INITPATH=%PATH%
+
+  - ps: 'Write-Host "Configuring PATH with $env:PYTHON" -ForegroundColor Magenta'
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+
+  - ps: 'Write-Host "Configuring MSVC compiler $env:COMPILER" -ForegroundColor Magenta'
+  - if %COMPILER%==msvc2017 ( call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH% )
+
+  - ps: 'Write-Host "Cached dependency folder" -ForegroundColor Magenta'
+  - if not exist C:\projects\deps mkdir C:\projects\deps
+  - dir C:\projects\deps
+
+  - set GEOSINSTALL=C:\projects\deps\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
+  - set CYTHONPF=C:\\projects\\deps\\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
+  - ps: 'Write-Host "Checking GEOS build $env:GEOSINSTALL" -ForegroundColor Magenta'
+  - call %APPVEYOR_BUILD_FOLDER%\scripts\build_geos.cmd
+
+  - ps: 'Write-Host "Copying and checking geos_c.dll" -ForegroundColor Magenta'
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init Shapely
+  - cd Shapely
+  - git log -1
+  - if %ARCH%==x86 ( set CPDIR=DLLs_x86_VC9 )
+  - if %ARCH%==x64 ( set CPDIR=DLLs_AMD64_VC9 )
+  - xcopy %GEOSINSTALL%\bin\geos*.dll %CPDIR%
+  - cd %CPDIR%
+  - dumpbin /dependents geos_c.dll
+  - dumpbin /dependents %PYTHON%\python.exe
+  - python -c "import sys; print('Python ' + sys.version)"
+  - python -c "import ctypes; print(ctypes.CDLL('./geos_c.dll'))"
+  - cd ..
+
+  - ps: 'Write-Host "Building wheel" -ForegroundColor Magenta'
+  - pip install -r requirements-dev.txt
+  - set GEOS_LIBRARY_PATH=%GEOSINSTALL%\bin\geos_c.dll
+  - set PATH=%GEOSINSTALL%\bin;%PATH%
+  - python setup.py build_ext -I%CYTHONPF%\\include -lgeos_c -L%CYTHONPF%\\lib bdist_wheel
+
+  - ps: 'Write-Host "Checking pip install in a new environment" -ForegroundColor Magenta'
+  - set PATH=%_INITPATH%
+  - set GEOS_LIBRARY_PATH=
+  - '%PYTHON%\python.exe -m venv C:\projects\test'
+  - call C:\projects\test\Scripts\activate.bat
+  - pip install -r requirements-dev.txt
+  - cd dist
+  - pip install --no-index --find-links . --no-cache-dir shapely
+  - python -c "import shapely; print(shapely.__version__)"
+  - python -c "from shapely.geos import geos_version_string; print(geos_version_string)"
+  - python -c "from shapely import speedups; assert speedups.enabled"
+
+  - ps: 'Write-Host "Running pytest" -ForegroundColor Magenta'
+  - xcopy ..\tests tests\
+  - pytest
+
+cache:
+  - C:\projects\deps -> %APPVEYOR_BUILD_FOLDER%\scripts\build_geos.cmd
+
+artifacts:
+  - path: pygeos\dist\*.whl
+    name: wheel

--- a/scripts/build_geos.cmd
+++ b/scripts/build_geos.cmd
@@ -1,0 +1,25 @@
+REM This script is called from appveyor.yml
+
+if exist %GEOSINSTALL% (
+  echo Using cached %GEOSINSTALL%
+) else (
+  echo Building %GEOSINSTALL%
+
+  cd C:\projects
+
+  curl -fsSO http://download.osgeo.org/geos/geos-%GEOS_VERSION%.tar.bz2
+  7z x geos-%GEOS_VERSION%.tar.bz2
+  7z x geos-%GEOS_VERSION%.tar
+  cd geos-%GEOS_VERSION% || exit /B 5
+
+  pip install ninja
+  cmake --version
+
+  mkdir build
+  cd build
+  cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOSINSTALL% .. || exit /B 1
+  cmake --build . --config Release || exit /B 2
+  ctest . --config Release || exit /B 3
+  cmake --install . --config Release || exit /B 4
+  cd ..
+)

--- a/scripts/get_appveyor_artifacts.py
+++ b/scripts/get_appveyor_artifacts.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Download AppVeyor artifacts for shapely
+
+See https://www.appveyor.com/docs/api/projects-builds/
+
+Created on Tue Jan 21 12:06:02 2020
+
+@author: Mike Taves
+"""
+
+import os
+import requests
+import textwrap
+
+account = 'frsci'
+slug = 'shapely-wheels'
+
+api = 'https://ci.appveyor.com/api'
+
+
+def download_job_artifacts(job_id):
+    resp = requests.get(f'{api}/buildjobs/{job_id}/artifacts')
+    for artifact in resp.json():
+        filename = artifact['fileName']
+        print(f'downloading: {filename}')
+        resp = requests.get(f'{api}/buildjobs/{job_id}/artifacts/{filename}')
+        save_path = os.path.split(filename)[-1]
+        with open(save_path, 'wb') as f:
+            f.write(resp.content)
+
+
+def main(branch='master'):
+    print(f"Gathering last build information for branch '{branch}'")
+    resp = requests.get(f'{api}/projects/{account}/{slug}/branch/{branch}')
+    data = resp.json()
+    if 'build' not in data:
+        raise ValueError(data)
+    build = data['build']
+    jobs = build.get('jobs', [])
+    if not jobs:
+        raise ValueError('no jobs found')
+    print('Found {0} jobs for last build for {1}'.format(len(jobs), branch))
+    print('Commit id: ' + str(build['commitId']))
+    print(textwrap.indent(build['message'], '> '))
+    # Check if all jobs were built successfully with one artifact
+    job_ids = []
+    for job in jobs:
+        if job.get('status') != 'success':
+            raise ValueError('not all jobs were built successfully')
+        elif job.get('artifactsCount', 0) == 0:
+            raise ValueError('not all jobs produced artifacts')
+        job_ids.append(job['jobId'])
+    for job_id in job_ids:
+        download_job_artifacts(job_id)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--branch', default='master',
+        help='branch to download artifacts from (default: %(default)s)')
+    args = parser.parse_args()
+    main(**vars(args))


### PR DESCRIPTION
Migrating some of the shapely wheel building from the main repo to here. This is a related effort to https://github.com/pygeos/pygeos-wheels/pull/1

I have a few other ideas for the main shapely repo, such as re-formatting the appveyor script to do basic tests (and not build wheels), and clean up the other wheel build scripts that are in a few places.