### PR TITLE
Add Python 3.9 support to setup.py and CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,36 +1,33 @@
 ---
-image: Visual Studio 2017
+image: Visual Studio 2019
 platform: x64
 
 environment:
   global:
+    COMPILER: msvc2019
     GEOS_VERSION: "3.8.1"
 
   matrix:
     - PYTHON: "C:\\Python35"
       ARCH: x86
-      COMPILER: msvc2017
     - PYTHON: "C:\\Python35-x64"
       ARCH: x64
-      COMPILER: msvc2017
     - PYTHON: "C:\\Python36"
       ARCH: x86
-      COMPILER: msvc2017
     - PYTHON: "C:\\Python36-x64"
       ARCH: x64
-      COMPILER: msvc2017
     - PYTHON: "C:\\Python37"
       ARCH: x86
-      COMPILER: msvc2017
     - PYTHON: "C:\\Python37-x64"
       ARCH: x64
-      COMPILER: msvc2017
     - PYTHON: "C:\\Python38"
       ARCH: x86
-      COMPILER: msvc2017
     - PYTHON: "C:\\Python38-x64"
       ARCH: x64
-      COMPILER: msvc2017
+    - PYTHON: "C:\\Python39"
+      ARCH: x86
+    - PYTHON: "C:\\Python39-x64"
+      ARCH: x64
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -50,15 +47,15 @@ build_script:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
   - ps: 'Write-Host "Configuring MSVC compiler $env:COMPILER" -ForegroundColor Magenta'
-  - if %COMPILER%==msvc2017 ( call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH% )
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
 
   - ps: 'Write-Host "Cached dependency folder" -ForegroundColor Magenta'
   - if not exist C:\projects\deps mkdir C:\projects\deps
   - dir C:\projects\deps
 
-  - set GEOSINSTALL=C:\projects\deps\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
+  - set GEOS_INSTALL=C:\projects\deps\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
   - set CYTHONPF=C:\\projects\\deps\\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
-  - ps: 'Write-Host "Checking GEOS build $env:GEOSINSTALL" -ForegroundColor Magenta'
+  - ps: 'Write-Host "Checking GEOS build $env:GEOS_INSTALL" -ForegroundColor Magenta'
   - call %APPVEYOR_BUILD_FOLDER%\scripts\build_geos.cmd
 
   - ps: 'Write-Host "Copying and checking geos_c.dll" -ForegroundColor Magenta'
@@ -68,7 +65,7 @@ build_script:
   - git log -1
   - if %ARCH%==x86 ( set CPDIR=DLLs_x86_VC9 )
   - if %ARCH%==x64 ( set CPDIR=DLLs_AMD64_VC9 )
-  - xcopy %GEOSINSTALL%\bin\geos*.dll %CPDIR%
+  - xcopy %GEOS_INSTALL%\bin\geos*.dll %CPDIR%
   - cd %CPDIR%
   - dumpbin /dependents geos_c.dll
   - dumpbin /dependents %PYTHON%\python.exe
@@ -78,8 +75,8 @@ build_script:
 
   - ps: 'Write-Host "Building wheel" -ForegroundColor Magenta'
   - pip install -r requirements-dev.txt
-  - set GEOS_LIBRARY_PATH=%GEOSINSTALL%\bin\geos_c.dll
-  - set PATH=%GEOSINSTALL%\bin;%PATH%
+  - set GEOS_LIBRARY_PATH=%GEOS_INSTALL%\bin\geos_c.dll
+  - set PATH=%GEOS_INSTALL%\bin;%PATH%
   - python setup.py build_ext -I%CYTHONPF%\\include -lgeos_c -L%CYTHONPF%\\lib bdist_wheel
 
   - ps: 'Write-Host "Checking pip install in a new environment" -ForegroundColor Magenta'

--- a/scripts/build_geos.cmd
+++ b/scripts/build_geos.cmd
@@ -1,9 +1,9 @@
 REM This script is called from appveyor.yml
 
-if exist %GEOSINSTALL% (
-  echo Using cached %GEOSINSTALL%
+if exist %GEOS_INSTALL% (
+  echo Using cached %GEOS_INSTALL%
 ) else (
-  echo Building %GEOSINSTALL%
+  echo Building %GEOS_INSTALL%
 
   cd C:\projects
 
@@ -17,7 +17,7 @@ if exist %GEOSINSTALL% (
 
   mkdir build
   cd build
-  cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOSINSTALL% .. || exit /B 1
+  cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOS_INSTALL% .. || exit /B 1
   cmake --build . --config Release || exit /B 2
   ctest . --config Release || exit /B 3
   cmake --install . --config Release || exit /B 4


### PR DESCRIPTION
* Change AppVeyor image from 2017 to Visual Studio 2019
* Rename environment variable GEOSINSTALL -> GEOS_INSTALL

Related to https://github.com/pygeos/pygeos-wheels/pull/6 and a few others.

I have not modified `.travis.yml`, as I'm less familiar with the various build images where Python 3.9 is supported.