### PR TITLE
Add Python 3.10 for Windows (AppVeyor)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,10 @@ environment:
       ARCH: x86
     - PYTHON: "C:\\Python39-x64"
       ARCH: x64
+    - PYTHON: "C:\\Python310"
+      ARCH: x86
+    - PYTHON: "C:\\Python310-x64"
+      ARCH: x64
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.


### PR DESCRIPTION
Looks like the binary wheels for Python 3.10 on Windows could be built.

Closes https://github.com/Toblerity/Shapely/issues/1215